### PR TITLE
everest-core: add bbappend to remove unneeded config files

### DIFF
--- a/recipes-core/everest/everest-core_%.bbappend
+++ b/recipes-core/everest/everest-core_%.bbappend
@@ -1,0 +1,4 @@
+# cleanup installed config files
+do_install:append() {
+    rm -rf ${D}${sysconfdir}/everest/config*.yaml
+}


### PR DESCRIPTION
The idea is that the default EVerest build included many configurations which do not make sense an our embedded platforms, so let's drop them.

This should be merged in combination with https://github.com/EVerest/meta-everest/pull/19
