### PR TITLE
Finetune EVerest core build and fix/extend firmware update

### DIFF
--- a/bundles/core-bundle/post-install.d/00-tar-helper
+++ b/bundles/core-bundle/post-install.d/00-tar-helper
@@ -1,10 +1,10 @@
 #!/bin/sh
 #
-# This script is a helper to be sourced in scripts which uses tar. It tries to detect which
+# This script is a helper to be sourced in scripts which use tar. It tries to detect which
 # variant of tar is available to workaround passing the parameter --ignore-failed-read to
 # busybox's tar which does not know about this option.
 # For this the variable IGNORE_FAILED_READ is set to "--ignore-failed-read"
-# or empty which can then used in tar invocations.
+# or empty which can then be used in tar invocations.
 #
 
 IGNORE_FAILED_READ="--ignore-failed-read"

--- a/bundles/core-bundle/post-install.d/00-tar-helper
+++ b/bundles/core-bundle/post-install.d/00-tar-helper
@@ -1,0 +1,13 @@
+#!/bin/sh
+#
+# This script is a helper to be sourced in scripts which uses tar. It tries to detect which
+# variant of tar is available to workaround passing the parameter --ignore-failed-read to
+# busybox's tar which does not know about this option.
+# For this the variable IGNORE_FAILED_READ is set to "--ignore-failed-read"
+# or empty which can then used in tar invocations.
+#
+
+IGNORE_FAILED_READ="--ignore-failed-read"
+if [ "$(readlink $(command -v tar))" = "/bin/busybox.nosuid" ]; then
+	IGNORE_FAILED_READ=""
+fi

--- a/bundles/core-bundle/post-install.d/02-copy-config-files
+++ b/bundles/core-bundle/post-install.d/02-copy-config-files
@@ -9,7 +9,10 @@ SLOT_MOUNT_POINT="$2"
 BUNDLE_MOUNT_POINT="$3"
 
 if [ "$SLOT_CLASS" = "rootfs" ]; then
-	( xargs tar -c --ignore-failed-read -C / ) <<-EOF | tar -x -C "$SLOT_MOUNT_POINT"
+	# source helper
+	. "$BUNDLE_MOUNT_POINT/post-install.d/00-tar-helper"
+
+	( xargs tar -c $IGNORE_FAILED_READ -C / ) <<-EOF | tar -x -C "$SLOT_MOUNT_POINT"
 	/etc/hostname
 	/etc/hosts
 	/etc/machine-id
@@ -35,7 +38,7 @@ if [ "$SLOT_CLASS" = "rootfs" ]; then
 
 	# migrate older /root to /home/root if present
 	if [ -d /root/.ssh ]; then
-		( xargs tar -c --ignore-failed-read -C / ) <<-EOF | tar -x -C "$SLOT_MOUNT_POINT/home"
+		( xargs tar -c $IGNORE_FAILED_READ -C / ) <<-EOF | tar -x -C "$SLOT_MOUNT_POINT/home"
 		/root/.ssh
 		EOF
 	fi

--- a/bundles/core-bundle/post-install.d/10-copy-custom-ca-certs
+++ b/bundles/core-bundle/post-install.d/10-copy-custom-ca-certs
@@ -9,7 +9,10 @@ SLOT_MOUNT_POINT="$2"
 BUNDLE_MOUNT_POINT="$3"
 
 if [ "$SLOT_CLASS" = "rootfs" ]; then
-	( xargs tar -c --ignore-failed-read -C / ) <<-EOF | tar -x -C "$SLOT_MOUNT_POINT"
+	# source helper
+	. "$BUNDLE_MOUNT_POINT/post-install.d/00-tar-helper"
+
+	( xargs tar -c $IGNORE_FAILED_READ -C / ) <<-EOF | tar -x -C "$SLOT_MOUNT_POINT"
 	/usr/local/share/ca-certificates
 	EOF
 fi

--- a/bundles/core-bundle/post-install.d/20-copy-everest-config
+++ b/bundles/core-bundle/post-install.d/20-copy-everest-config
@@ -22,8 +22,10 @@ if [ "$SLOT_CLASS" = "rootfs" ]; then
 	EOF
 
 	# in releases up to v0.2.0, config.yaml was a symlink, so we add a special check here to
-	# fix things up by replacing the symlink with a plain file copy
-	if [ -L "$SLOT_MOUNT_POINT/etc/everest/config.yaml" ]; then
+	# fix things up by replacing the symlink with a plain file copy; (the 2nd condition is
+	# important to ensure that we are doing an EVerest to EVerest update)
+	if [ -L "$SLOT_MOUNT_POINT/etc/everest/config.yaml" ] && \
+	   [ -f /etc/everest/config.yaml ]; then
 		rm -f "$SLOT_MOUNT_POINT/etc/everest/config.yaml.new"
 		cat /etc/everest/config.yaml > "$SLOT_MOUNT_POINT/etc/everest/config.yaml.new"
 		mv "$SLOT_MOUNT_POINT/etc/everest/config.yaml.new" "$SLOT_MOUNT_POINT/etc/everest/config.yaml"

--- a/bundles/core-bundle/post-install.d/20-copy-everest-config
+++ b/bundles/core-bundle/post-install.d/20-copy-everest-config
@@ -1,0 +1,31 @@
+#!/bin/sh
+#
+# This script copies some configuration files and directories from current running system
+# to the updated partition (new system).
+#
+
+SLOT_CLASS="$1"
+SLOT_MOUNT_POINT="$2"
+BUNDLE_MOUNT_POINT="$3"
+
+if [ "$SLOT_CLASS" = "rootfs" ]; then
+	# source helper
+	. "$BUNDLE_MOUNT_POINT/post-install.d/00-tar-helper"
+
+	# note that the following copies symlinks as-is since tar option --dereference is not given
+	( xargs tar -c $IGNORE_FAILED_READ -C / ) <<-EOF | tar -x -C "$SLOT_MOUNT_POINT"
+	/etc/everest/config.yaml
+	/etc/everest/user-config
+	/etc/everest/ocpp-config.json
+	/etc/everest/certs
+	/var/lib/everest
+	EOF
+
+	# in releases up to v0.2.0, config.yaml was a symlink, so we add a special check here to
+	# fix things up by replacing the symlink with a plain file copy
+	if [ -L "$SLOT_MOUNT_POINT/etc/everest/config.yaml" ]; then
+		rm -f "$SLOT_MOUNT_POINT/etc/everest/config.yaml.new"
+		cat /etc/everest/config.yaml > "$SLOT_MOUNT_POINT/etc/everest/config.yaml.new"
+		mv "$SLOT_MOUNT_POINT/etc/everest/config.yaml.new" "$SLOT_MOUNT_POINT/etc/everest/config.yaml"
+	fi
+fi

--- a/packagegroups/packagegroup-bsp.bbappend
+++ b/packagegroups/packagegroup-bsp.bbappend
@@ -1,0 +1,7 @@
+#
+# Notes:
+# - tar is required for special options in update shell scripts
+#
+RDEPENDS:${PN} += " \
+    tar \
+"

--- a/recipes-core/everest/everest-core_%.bbappend
+++ b/recipes-core/everest/everest-core_%.bbappend
@@ -4,4 +4,7 @@ do_install:append() {
 
     # create persistent state directory
     install -d -m 0755 ${D}${localstatedir}/lib/everest
+
+    # remove unneeded files from image
+    rm -rf ${D}${datadir}/everest/docker
 }

--- a/recipes-core/everest/everest-core_%.bbappend
+++ b/recipes-core/everest/everest-core_%.bbappend
@@ -1,3 +1,37 @@
+# don't build/include undesired modules: some of the everest-core modules do not make sense
+# on our chargebyte embedded platforms, e.g. BSPs for other boards, javascript simulations
+# or similar; so the following list defines which modules we want to have in our standard image
+EVEREST_INCLUDE_MODULES = " \
+    API \
+    Auth \
+    DPM1000 \
+    DummyTokenProvider \
+    DummyTokenProviderManual \
+    DummyTokenValidator \
+    DummyV2G \
+    EnergyManager \
+    EnergyNode \
+    EvseManager \
+    EvseSecurity \
+    EvseSlac \
+    EvseV2G \
+    EvSlac \
+    GenericPowermeter \
+    LemDCBM400600 \
+    OCPP \
+    OCPP201 \
+    PacketSniffer \
+    PersistentStore \
+    PN532TokenProvider \
+    PowermeterBSM \
+    SerialCommHub \
+    Setup \
+    Store \
+    System \
+"
+
+EXTRA_OECMAKE += "-DEVEREST_INCLUDE_MODULES='${@";".join(d.getVar('EVEREST_INCLUDE_MODULES', True).split())}'"
+
 do_install:append() {
     # cleanup installed config files
     rm -rf ${D}${sysconfdir}/everest/config*.yaml

--- a/recipes-core/everest/everest-core_%.bbappend
+++ b/recipes-core/everest/everest-core_%.bbappend
@@ -1,4 +1,7 @@
-# cleanup installed config files
 do_install:append() {
+    # cleanup installed config files
     rm -rf ${D}${sysconfdir}/everest/config*.yaml
+
+    # create persistent state directory
+    install -d -m 0755 ${D}${localstatedir}/lib/everest
 }


### PR DESCRIPTION
This PR bundles two points:
- it finetunes the chargebyte's default image build for Tarragon platform
- it fixes and extends config file handling during firmware update
