### PR TITLE
packagegroups: include burnutil tool in image build

### DIFF
--- a/packagegroups/packagegroup-common.bbappend
+++ b/packagegroups/packagegroup-common.bbappend
@@ -1,0 +1,5 @@
+# Workaround: internal production environment requires the tool "burnutil"
+# to be included in the installed firmware but since we don't have a normal
+# user (dependency) we have to force-pull it here. This might be reverted
+# when the internal production process is adapted.
+RDEPENDS:${PN} += "libcrypti2c"


### PR DESCRIPTION
The current production process requires the tool to be included in the flashed, final firmware.

In our EVerest environment, it is not required by any other package anymore, so it is missing. Pull it in here, so that the process is happy until the process was adapted.