### PR TITLE
Fixes related to upcoming chargebyte release with EVerest 2024.3.0

### DIFF
--- a/packagegroups/packagegroup-everest.bb
+++ b/packagegroups/packagegroup-everest.bb
@@ -18,5 +18,4 @@ RDEPENDS:${PN} = " \
     tzdata tzdata-europe \
     mosquitto-clients \
     tcpdump \
-    yq \
 "

--- a/recipes-backports/date/date_%.bbappend
+++ b/recipes-backports/date/date_%.bbappend
@@ -1,0 +1,3 @@
+EXTRA_OECMAKE += " \
+	-DBUILD_SHARED_LIBS=ON \
+"

--- a/recipes-core/everest/everest-core_%.bbappend
+++ b/recipes-core/everest/everest-core_%.bbappend
@@ -3,6 +3,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 SRC_URI += " \
     file://0001-Implement-system-interface.patch \
     file://0001-System-delayed-reset-execution.patch \
+    file://0001-System-don-t-download-to-tmp-but-to-srv.patch \
 "
 
 # don't build/include undesired modules: some of the everest-core modules do not make sense

--- a/recipes-core/everest/files/0001-System-don-t-download-to-tmp-but-to-srv.patch
+++ b/recipes-core/everest/files/0001-System-don-t-download-to-tmp-but-to-srv.patch
@@ -1,0 +1,36 @@
+From f9a5646a32afb36d123666fd686e4d9c8d4c193d Mon Sep 17 00:00:00 2001
+From: Michael Heimpold <michael.heimpold@chargebyte.com>
+Date: Thu, 25 Apr 2024 14:17:39 +0200
+Subject: [PATCH] System: don't download to /tmp but to /srv
+
+Signed-off-by: Michael Heimpold <michael.heimpold@chargebyte.com>
+---
+ modules/System/main/systemImpl.cpp | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/modules/System/main/systemImpl.cpp b/modules/System/main/systemImpl.cpp
+index 7b46d2e..ce4f84c 100644
+--- a/modules/System/main/systemImpl.cpp
++++ b/modules/System/main/systemImpl.cpp
+@@ -115,9 +115,17 @@ void systemImpl::standard_firmware_update(const types::system::FirmwareUpdateReq
+     // create temporary file
+     const auto date_time = Everest::Date::to_rfc3339(date::utc_clock::now());
+ 
+-    const auto firmware_file_path = create_temp_file(fs::temp_directory_path(), "firmware-" + date_time);
++    // Note: we don't download to /tmp as in vanilla everest since our download sizes
++    // might be larger than available RAM;
++    // we use a fixed path for now so that we can ensure a cleanup...
++    const auto firmware_file_path = fs::path("/srv/firmware-update.image");
+     const auto constants = this->scripts_path / CONSTANTS;
+ 
++    // ...here by deleting a possibly existing, older file
++    if (fs::exists(firmware_file_path)) {
++        fs::remove(firmware_file_path);
++    }
++
+     this->update_firmware_thread = std::thread([this, firmware_update_request, firmware_file_path, constants]() {
+         const auto firmware_updater = this->scripts_path / FIRMWARE_UPDATER;
+ 
+-- 
+2.34.1
+

--- a/recipes-core/remotechargeport/remotechargeport_git.bb
+++ b/recipes-core/remotechargeport/remotechargeport_git.bb
@@ -10,8 +10,8 @@ SRC_URI = " \
     file://systemaggregatorftpd@.service \
 "
 
-SRCREV = "d7d826797818060b3a236cba9b33874310a10463"
-PV = "2024.03.0+git${SRCPV}"
+SRCREV = "1280bc18ebfbdf6c762c612b953d369b539f74f4"
+PV = "2024.03.1+git${SRCPV}"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
This fixes two issues:
- the firmware update via OCPP might fail due to firmware image size
- GetDiagnostics in dual charger setups fails due to incomplete implementation in SystemAggregator module
