### PR TITLE
Improve logging on chargebyte devices

### DIFF
--- a/recipes-core/everest/everest-core_%.bbappend
+++ b/recipes-core/everest/everest-core_%.bbappend
@@ -1,6 +1,8 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI += " \
+    file://0001-Drop-timestamp-from-logging.patch \
+    file://journalctl-alias.sh \
     file://0001-Implement-system-interface.patch \
     file://0001-System-delayed-reset-execution.patch \
     file://0001-System-don-t-download-to-tmp-but-to-srv.patch \
@@ -51,4 +53,8 @@ do_install:append() {
 
     # remove unneeded files from image
     rm -rf ${D}${datadir}/everest/docker
+
+    # install alias for journalctl convenience
+    install -d ${D}${sysconfdir}/profile.d/
+    install -m 0644 ${WORKDIR}/journalctl-alias.sh ${D}${sysconfdir}/profile.d/
 }

--- a/recipes-core/everest/files/0001-Drop-timestamp-from-logging.patch
+++ b/recipes-core/everest/files/0001-Drop-timestamp-from-logging.patch
@@ -1,0 +1,36 @@
+From 33716b2856a481ac5cd36dd47ec7d8a05e58a080 Mon Sep 17 00:00:00 2001
+From: Michael Heimpold <michael.heimpold@chargebyte.com>
+Date: Wed, 8 May 2024 17:17:37 +0200
+Subject: [PATCH] Drop timestamp from logging
+
+The output is captured by systemd-journald on chargebyte platforms,
+which already adds a timestamp with higher precision to each line.
+
+We can thus drop the timestamp here.
+
+(This change comes in combination with a patch which outputs
+the journald timestamp with this higher precision by default when
+called interactively.)
+
+Signed-off-by: Michael Heimpold <michael.heimpold@chargebyte.com>
+Upstream-Status: Inappropriate [makes only sense on environment controlled platforms]
+---
+ cmake/assets/logging.ini | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cmake/assets/logging.ini b/cmake/assets/logging.ini
+index 516f336..8a65156 100644
+--- a/cmake/assets/logging.ini
++++ b/cmake/assets/logging.ini
+@@ -14,7 +14,7 @@ Filter="%Severity% >= INFO"
+ [Sinks.Console]
+ Destination=Console
+ # Filter="%Target% contains \"MySink1\""
+-Format="%TimeStamp% [%Severity%] \033[1;32m%Process%\033[0m \033[1;36m%function%\033[0m \033[1;30m%file%:\033[0m\033[1;32m%line%\033[0m: %Message%"
++Format="[%Severity%] \033[1;32m%Process%\033[0m \033[1;36m%function%\033[0m \033[1;30m%file%:\033[0m\033[1;32m%line%\033[0m: %Message%"
+ Asynchronous=false
+ AutoFlush=true
+ SeverityStringColorDebug="\033[1;30m"
+-- 
+2.34.1
+

--- a/recipes-core/everest/files/journalctl-alias.sh
+++ b/recipes-core/everest/files/journalctl-alias.sh
@@ -1,0 +1,2 @@
+# print high-resolution timestamp by default
+alias journalctl='journalctl -o short-iso-precise'

--- a/recipes-core/systemd/files/journald.conf
+++ b/recipes-core/systemd/files/journald.conf
@@ -1,0 +1,8 @@
+#
+# On chargebyte platforms, a dedicated partition (128 MiB) is used for /var/log,
+# so that we can use persistent journals.
+# Note: the current version of systemd does not accept percent values yet.
+#
+[Journal]
+Storage=persistent
+SystemMaxUse=96M

--- a/recipes-core/systemd/systemd-conf_%.bbappend
+++ b/recipes-core/systemd/systemd-conf_%.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"


### PR DESCRIPTION
This makes the logging persistent using a journal on our dedicated log partition.

And it strips the EVerest own timestamp, since we can use the journald one.
