### PR TITLE
Adapt to EVerest release 2024.8.0

### DIFF
--- a/recipes-core/everest-chargebyte/everest-chargebyte_git.bb
+++ b/recipes-core/everest-chargebyte/everest-chargebyte_git.bb
@@ -3,8 +3,8 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 
 SRC_URI = "git://github.com/chargebyte/everest-chargebyte.git;branch=main;protocol=https"
 
-SRCREV = "0d4281c7137ebc9845b98562239c34bfc9d91c8e"
-PV = "0.15.0+git${SRCPV}"
+SRCREV = "fafbdd15570c656d482bad7c38e71bd587525f8b"
+PV = "0.16.0+git${SRCPV}"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-core/everest-chargebyte/everest-chargebyte_git.bb
+++ b/recipes-core/everest-chargebyte/everest-chargebyte_git.bb
@@ -3,8 +3,8 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 
 SRC_URI = "git://github.com/chargebyte/everest-chargebyte.git;branch=main;protocol=https"
 
-SRCREV = "9709c13993eca6716c9664b05d4de3033a13771f"
-PV = "0.14.0+git${SRCPV}"
+SRCREV = "0d4281c7137ebc9845b98562239c34bfc9d91c8e"
+PV = "0.15.0+git${SRCPV}"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-core/everest/everest-core_%.bbappend
+++ b/recipes-core/everest/everest-core_%.bbappend
@@ -4,6 +4,7 @@ SRC_URI += " \
     file://0001-Drop-timestamp-from-logging.patch \
     file://journalctl-alias.sh \
     file://0001-Registered-time_sync_callback-in-OCPP201-module.patch \
+    file://0001-API-make-error-history-requirement-optional.patch \
 "
 
 # don't build/include undesired modules: some of the everest-core modules do not make sense

--- a/recipes-core/everest/everest-core_%.bbappend
+++ b/recipes-core/everest/everest-core_%.bbappend
@@ -3,6 +3,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 SRC_URI += " \
     file://0001-Drop-timestamp-from-logging.patch \
     file://journalctl-alias.sh \
+    file://0001-Registered-time_sync_callback-in-OCPP201-module.patch \
 "
 
 # don't build/include undesired modules: some of the everest-core modules do not make sense

--- a/recipes-core/everest/everest-core_%.bbappend
+++ b/recipes-core/everest/everest-core_%.bbappend
@@ -42,6 +42,9 @@ EVEREST_INCLUDE_MODULES = " \
 "
 
 EXTRA_OECMAKE += "-DEVEREST_INCLUDE_MODULES='${@";".join(d.getVar('EVEREST_INCLUDE_MODULES', True).split())}'"
+# force use of mbedtls (for EvseV2G)
+EXTRA_OECMAKE += "-DUSING_MBED_TLS=ON"
+DEPENDS += "mbedtls"
 
 do_install:append() {
     # cleanup installed config files

--- a/recipes-core/everest/files/0001-API-make-error-history-requirement-optional.patch
+++ b/recipes-core/everest/files/0001-API-make-error-history-requirement-optional.patch
@@ -1,0 +1,79 @@
+From 940c920129ad2a25360e484dcf0a3e9f3daa1b88 Mon Sep 17 00:00:00 2001
+From: Kai-Uwe Hermann <kai-uwe.hermann@pionix.de>
+Date: Wed, 4 Sep 2024 11:26:21 +0200
+Subject: [PATCH] API: make error history requirement optional
+
+Signed-off-by: Kai-Uwe Hermann <kai-uwe.hermann@pionix.de>
+---
+ modules/API/API.cpp       | 16 +++++++++-------
+ modules/API/API.hpp       |  4 ++--
+ modules/API/manifest.yaml |  2 ++
+ 3 files changed, 13 insertions(+), 9 deletions(-)
+
+diff --git a/modules/API/API.cpp b/modules/API/API.cpp
+index 28216554..361b179b 100644
+--- a/modules/API/API.cpp
++++ b/modules/API/API.cpp
+@@ -617,15 +617,17 @@ void API::ready() {
+         auto next_tick = std::chrono::steady_clock::now();
+         while (this->running) {
+             std::string datetime_str = Everest::Date::to_rfc3339(date::utc_clock::now());
+-            // request active errors
+-            types::error_history::FilterArguments filter;
+-            filter.state_filter = types::error_history::State::Active;
+-            auto active_errors = r_error_history->call_get_errors(filter);
+-            json errors_json = json(active_errors);
+ 
+-            // publish
+-            this->mqtt.publish(var_active_errors, errors_json.dump());
++            if (not r_error_history.empty()) {
++                // request active errors
++                types::error_history::FilterArguments filter;
++                filter.state_filter = types::error_history::State::Active;
++                auto active_errors = r_error_history.at(0)->call_get_errors(filter);
++                json errors_json = json(active_errors);
+ 
++                // publish
++                this->mqtt.publish(var_active_errors, errors_json.dump());
++            }
+             next_tick += NOTIFICATION_PERIOD;
+             std::this_thread::sleep_until(next_tick);
+         }
+diff --git a/modules/API/API.hpp b/modules/API/API.hpp
+index 0a089330..5aa7b132 100644
+--- a/modules/API/API.hpp
++++ b/modules/API/API.hpp
+@@ -155,7 +155,7 @@ public:
+     API(const ModuleInfo& info, Everest::MqttProvider& mqtt_provider, std::unique_ptr<emptyImplBase> p_main,
+         std::vector<std::unique_ptr<evse_managerIntf>> r_evse_manager, std::vector<std::unique_ptr<ocppIntf>> r_ocpp,
+         std::vector<std::unique_ptr<uk_random_delayIntf>> r_random_delay,
+-        std::unique_ptr<error_historyIntf> r_error_history, Conf& config) :
++        std::vector<std::unique_ptr<error_historyIntf>> r_error_history, Conf& config) :
+         ModuleBase(info),
+         mqtt(mqtt_provider),
+         p_main(std::move(p_main)),
+@@ -170,7 +170,7 @@ public:
+     const std::vector<std::unique_ptr<evse_managerIntf>> r_evse_manager;
+     const std::vector<std::unique_ptr<ocppIntf>> r_ocpp;
+     const std::vector<std::unique_ptr<uk_random_delayIntf>> r_random_delay;
+-    const std::unique_ptr<error_historyIntf> r_error_history;
++    const std::vector<std::unique_ptr<error_historyIntf>> r_error_history;
+     const Conf& config;
+ 
+     // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
+diff --git a/modules/API/manifest.yaml b/modules/API/manifest.yaml
+index f72e6bde..ec1b0e9f 100644
+--- a/modules/API/manifest.yaml
++++ b/modules/API/manifest.yaml
+@@ -187,6 +187,8 @@ requires:
+     max_connections: 128
+   error_history:
+     interface: error_history
++    min_connections: 0
++    max_connections: 1
+ enable_external_mqtt: true
+ metadata:
+   license: https://opensource.org/licenses/Apache-2.0
+-- 
+2.34.1
+

--- a/recipes-core/everest/files/0001-Added-certificate-validation-to-FirwmareUpdate.req-h.patch
+++ b/recipes-core/everest/files/0001-Added-certificate-validation-to-FirwmareUpdate.req-h.patch
@@ -1,0 +1,45 @@
+From 46f14dd93d1286e12bfa7ec4131a8dcbada56869 Mon Sep 17 00:00:00 2001
+From: pietfried <pietgoempel@gmail.com>
+Date: Mon, 5 Aug 2024 11:29:33 +0200
+Subject: [PATCH] Added certificate validation to FirwmareUpdate.req handler in
+ ocpp201
+
+Signed-off-by: pietfried <pietgoempel@gmail.com>
+---
+ lib/ocpp/v201/charge_point.cpp | 19 ++++++++++++++++++-
+ 1 file changed, 18 insertions(+), 1 deletion(-)
+
+diff --git a/lib/ocpp/v201/charge_point.cpp b/lib/ocpp/v201/charge_point.cpp
+index 3c9ec43a..185bc43a 100644
+--- a/lib/ocpp/v201/charge_point.cpp
++++ b/lib/ocpp/v201/charge_point.cpp
+@@ -3154,8 +3154,25 @@ void ChargePoint::handle_firmware_update_req(Call<UpdateFirmwareRequest> call) {
+     } else {
+         this->firmware_status_before_installing = FirmwareStatusEnum::Downloaded;
+     }
+-    UpdateFirmwareResponse response = callbacks.update_firmware_request_callback(call.msg);
+ 
++    UpdateFirmwareResponse response;
++    const auto msg = call.msg;
++    bool cert_valid_or_not_set = true;
++
++    // L01.FR.22 check if certificate is valid
++    if (msg.firmware.signingCertificate.has_value() and
++        this->evse_security->verify_certificate(msg.firmware.signingCertificate.value().get(),
++                                                ocpp::LeafCertificateType::MF) !=
++            ocpp::CertificateValidationResult::Valid) {
++        response.status = UpdateFirmwareStatusEnum::InvalidCertificate;
++        cert_valid_or_not_set = false;
++    } 
++    
++    if (cert_valid_or_not_set) {
++        // execute firwmare update callback
++        response = callbacks.update_firmware_request_callback(msg);
++    }
++    
+     ocpp::CallResult<UpdateFirmwareResponse> call_result(response, call.uniqueId);
+     this->send<UpdateFirmwareResponse>(call_result);
+ 
+-- 
+2.34.1
+

--- a/recipes-core/everest/files/0001-ChargePoint-add-support-for-SecurityEventNotificatio.patch
+++ b/recipes-core/everest/files/0001-ChargePoint-add-support-for-SecurityEventNotificatio.patch
@@ -1,0 +1,37 @@
+From d8b4dc808cbb6d2f7b037f23cad4edf61f8adefc Mon Sep 17 00:00:00 2001
+From: Moritz Barsnick <moritz.barsnick@chargebyte.com>
+Date: Tue, 13 Aug 2024 15:47:33 +0200
+Subject: [PATCH] ChargePoint: add support for SecurityEventNotification
+ `FirmwareUpdated` after reboot
+
+It was being reported as ResetOrReboot.
+
+This addition is to fulfil requirement L01.FR.31 when the firmware requires
+a reboot after installation. The case without reboot is handled in
+on_firmware_update_status_notification().
+
+Signed-off-by: Moritz Barsnick <moritz.barsnick@chargebyte.com>
+---
+ lib/ocpp/v201/charge_point.cpp | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/lib/ocpp/v201/charge_point.cpp b/lib/ocpp/v201/charge_point.cpp
+index 3c9ec43a..d63a4860 100644
+--- a/lib/ocpp/v201/charge_point.cpp
++++ b/lib/ocpp/v201/charge_point.cpp
+@@ -234,6 +234,12 @@ void ChargePoint::start(BootReasonEnum bootreason) {
+             this->device_model->get_value<std::string>(ControllerComponentVariables::FirmwareVersion));
+         this->security_event_notification_req(CiString<50>(ocpp::security_events::STARTUP_OF_THE_DEVICE),
+                                               std::optional<CiString<255>>(startup_message), true, true);
++    } else if (this->bootreason == BootReasonEnum::FirmwareUpdate) {
++        std::string startup_message = "Charging station reboot after firmware update. Firmware version: ";
++        startup_message.append(
++            this->device_model->get_value<std::string>(ControllerComponentVariables::FirmwareVersion));
++        this->security_event_notification_req(CiString<50>(ocpp::security_events::FIRMWARE_UPDATED),
++                                              std::optional<CiString<255>>(startup_message), true, true);
+     } else {
+         std::string startup_message = "Charging station reset or reboot. Firmware version: ";
+         startup_message.append(
+-- 
+2.34.1
+

--- a/recipes-core/everest/files/0001-Registered-time_sync_callback-in-OCPP201-module.patch
+++ b/recipes-core/everest/files/0001-Registered-time_sync_callback-in-OCPP201-module.patch
@@ -1,0 +1,28 @@
+From 342caf3345f581c88054de3d78c3f173d7a08aad Mon Sep 17 00:00:00 2001
+From: pietfried <pietgoempel@gmail.com>
+Date: Mon, 5 Aug 2024 13:45:55 +0200
+Subject: [PATCH] Registered time_sync_callback in OCPP201 module
+
+Signed-off-by: pietfried <pietgoempel@gmail.com>
+---
+ modules/OCPP201/OCPP201.cpp | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/modules/OCPP201/OCPP201.cpp b/modules/OCPP201/OCPP201.cpp
+index fe92ae85..6fe989a2 100644
+--- a/modules/OCPP201/OCPP201.cpp
++++ b/modules/OCPP201/OCPP201.cpp
+@@ -529,6 +529,10 @@ void OCPP201::ready() {
+         return;
+     };
+ 
++    callbacks.time_sync_callback = [this](const ocpp::DateTime& current_time) {
++        this->r_system->call_set_system_time(current_time.to_rfc3339());
++    };
++
+     const auto sql_init_path = this->ocpp_share_path / SQL_CORE_MIGRATIONS;
+ 
+     std::map<int32_t, int32_t> evse_connector_structure = this->get_connector_structure();
+-- 
+2.34.1
+

--- a/recipes-core/everest/libocpp_%.bbappend
+++ b/recipes-core/everest/libocpp_%.bbappend
@@ -1,0 +1,6 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += " \
+    file://0001-Added-certificate-validation-to-FirwmareUpdate.req-h.patch \
+    file://0001-ChargePoint-add-support-for-SecurityEventNotificatio.patch \
+"

--- a/recipes-core/remotechargeport/remotechargeport_git.bb
+++ b/recipes-core/remotechargeport/remotechargeport_git.bb
@@ -10,8 +10,8 @@ SRC_URI = " \
     file://systemaggregatorftpd@.service \
 "
 
-SRCREV = "747fee5698c9d004df668a4c115dc63a06a60789"
-PV = "2024.07.0+git${SRCPV}"
+SRCREV = "2e795b71b79ad43f97256a6730d2c5f6175781f5"
+PV = "2024.08.0+git${SRCPV}"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
This adapts our EVerest configuration to EVerest 2024.8.0.

It adds several patches for OCPP 2.0.1.

The commit "[everest-chargebyte: switch to branch with system interface fixes](https://github.com/chargebyte/meta-chargebyte-everest/commit/3d97c3035f6f8456a36a5becf610ab86bc1f3944)" will be dropped (adapted to new git hash) once the branch and its PR is merged.

Please have an extra look at [everest-core: force use of mbedtls](https://github.com/chargebyte/meta-chargebyte-everest/commit/d50e1b1c240dece1309a0b90808201d33ba03adf). It is currently untested.