### PR TITLE
systemd-conf: adapt systemd-journald settings

### DIFF
--- a/recipes-core/systemd/files/journald.conf
+++ b/recipes-core/systemd/files/journald.conf
@@ -6,3 +6,5 @@
 [Journal]
 Storage=persistent
 SystemMaxUse=96M
+MaxRetentionSec=7days
+MaxFileSec=1day


### PR DESCRIPTION
This adds two settings for better usage of the journal and its archive.

The reduced MaxFileSec ensures that the journal log files are created more often and thereby easier to rotate and delete to free up space.

MaxRetentionSec ensures that no useless old log data is kept around.