### PR TITLE
Make correct phase count available in API

### DIFF
--- a/recipes-core/everest/everest-core_%.bbappend
+++ b/recipes-core/everest/everest-core_%.bbappend
@@ -5,6 +5,7 @@ SRC_URI += " \
     file://journalctl-alias.sh \
     file://0001-Registered-time_sync_callback-in-OCPP201-module.patch \
     file://0001-API-make-error-history-requirement-optional.patch \
+    file://0001-Make-correct-phase-count-available-in-API \
 "
 
 # don't build/include undesired modules: some of the everest-core modules do not make sense

--- a/recipes-core/everest/files/0001-Make-correct-phase-count-available-in-API.patch
+++ b/recipes-core/everest/files/0001-Make-correct-phase-count-available-in-API.patch
@@ -1,0 +1,71 @@
+From 0f711174eb08b853f79b67ff28e2f134aa0bf683 Mon Sep 17 00:00:00 2001
+From: Martin Lukas <martin.lukas@chargebyte.com>
+Date: Mon, 23 Sep 2024 06:58:32 +0200
+Subject: [PATCH] Make correct phase count available in API
+
+ The available phase count is part of the type "evse_manager::limits". 
+ This type is published via mqtt and is used by the API module to interact
+ with external software stacks like Nymea.
+ Per default, the available phase count is set to value 1, during the init of the
+ evse_manager interface. The EvseManager determines the count of active phases
+ with help of the min and max phase count values as part of the type
+ "evse_board_support::HardwareCapabilities". This is published by other
+ modules like CbTarragonDriver. But this value is never published via "limits"
+ topic through API module. This leads to wrong values in the Nymea App.
+ Although 3 phases are connected to wallbox, only 1 phase is used for energy
+ management. This commit should fix this.
+
+Signed-off-by: Martin Lukas <martin.lukas@chargebyte.com>
+---
+ modules/EvseManager/EvseManager.cpp           |  2 ++
+ modules/EvseManager/evse/evse_managerImpl.cpp | 14 +++++++-------
+ 2 files changed, 9 insertions(+), 7 deletions(-)
+
+diff --git a/modules/EvseManager/EvseManager.cpp b/modules/EvseManager/EvseManager.cpp
+index 6d64a4a..22e69e6 100644
+--- a/modules/EvseManager/EvseManager.cpp
++++ b/modules/EvseManager/EvseManager.cpp
+@@ -139,6 +139,8 @@ void EvseManager::init() {
+             ac_nr_phases_active = c.min_phase_count_import;
+         }
+ 
++        signalNrOfPhasesAvailable(ac_nr_phases_active);
++
+         bsp->set_three_phases(c.max_phase_count_import);
+         charger->set_connector_type(c.connector_type);
+         p_evse->publish_hw_capabilities(c);
+diff --git a/modules/EvseManager/evse/evse_managerImpl.cpp b/modules/EvseManager/evse/evse_managerImpl.cpp
+index bb4efa2..168b678 100644
+--- a/modules/EvseManager/evse/evse_managerImpl.cpp
++++ b/modules/EvseManager/evse/evse_managerImpl.cpp
+@@ -26,6 +26,13 @@ void evse_managerImpl::init() {
+     limits.nr_of_phases_available = 1;
+     limits.max_current = 0.;
+ 
++    mod->signalNrOfPhasesAvailable.connect([this](const int n) {
++        if (n >= 1 && n <= 3) {
++            limits.nr_of_phases_available = n;
++            publish_limits(limits);
++        }
++    });
++
+     // Interface to Node-RED debug UI
+ 
+     mod->mqtt.subscribe(
+@@ -117,13 +124,6 @@ void evse_managerImpl::ready() {
+     // publish evse id at least once
+     publish_evse_id(mod->config.evse_id);
+ 
+-    mod->signalNrOfPhasesAvailable.connect([this](const int n) {
+-        if (n >= 1 && n <= 3) {
+-            limits.nr_of_phases_available = n;
+-            publish_limits(limits);
+-        }
+-    });
+-
+     mod->r_bsp->subscribe_telemetry([this](types::evse_board_support::Telemetry telemetry) {
+         // external Nodered interface
+         mod->mqtt.publish(fmt::format("everest_external/nodered/{}/state/temperature", mod->config.connector_id),
+-- 
+2.34.1
+


### PR DESCRIPTION
The available phase count is part of the type "evse_manager::limits".
This type is published via mqtt and is used by the API module to interact with external software stacks like Nymea.
Per default the available phase count is set to value 1, during the init of the evse_manager interface. The EvseManager determines the count of active phases with help of the min and max phase count values as part of the type "evse_board_support::HardwareCapabilities". This is published by other modules like CbTarragonDriver.
But this value is never published via "limits" topic through API module. This leads to wrong values in the Nymea App. Although 3 phases are connected to wallbox, only 1 phase is used for energy management. This commit should fix this.