### PR TITLE
everest-core: drop YetiSimulator from build

### DIFF
--- a/recipes-core/everest/everest-core_%.bbappend
+++ b/recipes-core/everest/everest-core_%.bbappend
@@ -77,7 +77,6 @@ EVEREST_INCLUDE_MODULES = " \
     System \
     UUGreenPower_UR1000X0 \
     YamlStore \
-    YetiSimulator \
 "
 
 EXTRA_OECMAKE += "-DEVEREST_INCLUDE_MODULES='${@";".join(d.getVar('EVEREST_INCLUDE_MODULES', True).split())}'"


### PR DESCRIPTION
We should not ship simulations for other BSPs in our builds. YetiSimulator can be used in SIL environments on hosts, but I see no use-case to ship it on our products.