### PR TITLE
core-bundle: also copy the EVerest logging configuration

### DIFF
--- a/bundles/core-bundle/post-install.d/20-copy-everest-config
+++ b/bundles/core-bundle/post-install.d/20-copy-everest-config
@@ -17,6 +17,7 @@ if [ "$SLOT_CLASS" = "rootfs" ]; then
 	/etc/everest/config.yaml
 	/etc/everest/user-config
 	/etc/everest/ocpp-config.json
+	/etc/everest/default_logging.cfg
 	/etc/everest/certs
 	/var/lib/everest
 	EOF


### PR DESCRIPTION
The customer may have changed something to the way EVerest logs, and will want to keep that change. The same is valid for debugging purposes. 