### PR TITLE
packagegroup-develop: include ftxui

### DIFF
--- a/packagegroups/packagegroup-develop.bbappend
+++ b/packagegroups/packagegroup-develop.bbappend
@@ -4,3 +4,7 @@ RDEPENDS:${PN} += "sigslot-dev"
 # on the Charge SOM platform, we have sufficient free space and enough
 # CPU power to use these tools
 RDEPENDS:${PN} += "${@bb.utils.contains("MACHINE", "chargesom", "node-red nodejs-npm", "", d)}"
+
+# we exclude the dependency in EVerest recipe but the library should be
+# available in our developer rootfs so users can cross-build bringup modules
+RDEPENDS:${PN} += "ftxui"


### PR DESCRIPTION
The library is not pulled-in automatically because we exclude bringup modules of EVerest by default.
But in case we want to build the bringup modules later manually, let's ensure that the library is present in the image.