### PR TITLE
mosquitto: add a Unix listener for EVerest

### DIFF
--- a/recipes-connectivity/mosquitto/files/10-everest-unix-domain-socket.conf
+++ b/recipes-connectivity/mosquitto/files/10-everest-unix-domain-socket.conf
@@ -1,0 +1,1 @@
+listener 0 /run/mosquitto/everest.socket

--- a/recipes-connectivity/mosquitto/mosquitto_%.bbappend
+++ b/recipes-connectivity/mosquitto/mosquitto_%.bbappend
@@ -1,0 +1,10 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://10-everest-unix-domain-socket.conf"
+
+do_install:append() {
+    install -d ${D}${nonarch_base_libdir}/mosquitto/conf.d
+    install -m 644 ${WORKDIR}/10-everest-unix-domain-socket.conf ${D}${nonarch_base_libdir}/mosquitto/conf.d/10-everest-unix-domain-socket.conf
+}
+
+FILES:${PN}:append = " ${nonarch_base_libdir}/mosquitto/conf.d"


### PR DESCRIPTION
This adds a static configuration providing a Unix domain socket as an additional listener for EVerest.

The EVerest stack needs to explicitly be configured to use this socket instead of a TCP socket.

This depends on a configuration in meta-chargebyte-distro's mosquitto.conf in order to take effect, see https://github.com/chargebyte/meta-chargebyte-distro/pull/31.